### PR TITLE
fixes type error on disclosure button in navbar

### DIFF
--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -179,22 +179,22 @@ export default function Navbar({ user }: { user: any }) {
                     </div>
                   </div>
                   <div className="mt-3 space-y-1">
-                    <Disclosure.Button
+                    <button
                       onClick={() => signOut()}
                       className="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
                     >
                       Sign out
-                    </Disclosure.Button>
+                    </button>
                   </div>
                 </>
               ) : (
                 <div className="mt-3 space-y-1">
-                  <Disclosure.Button
+                  <button
                     onClick={() => signIn('github')}
                     className="flex w-full px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
                   >
                     Sign in
-                  </Disclosure.Button>
+                  </button>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Fixes: #4 

Disclosure.Buttons are used incorrectly here since they do not provide an `onClick` handler (hence type error).
They should be used in conjunction with the Disclosure.Panel to reveal their contents. The previous code appears to treat these as regular buttons (no corresponding panel) so i have used `button` instead.

<img width="834" alt="image" src="https://user-images.githubusercontent.com/3030010/227065981-0c970e05-0fcd-497f-b970-3ba1242ab815.png">

<img width="872" alt="image" src="https://user-images.githubusercontent.com/3030010/227066002-39dc6bfe-282b-400c-90f0-de306db421ef.png">
